### PR TITLE
fix PgsqlInfo::fetchAutoincSequence() method for columns with no default value

### DIFF
--- a/src/PgsqlInfo.php
+++ b/src/PgsqlInfo.php
@@ -53,7 +53,7 @@ class PgsqlInfo extends Info
         );
 
         foreach ($cols as $name => $default) {
-            if (substr($default, 0, 9) == "nextval('"
+            if ($default !== null && substr($default, 0, 9) == "nextval('"
             ) {
                 $pos = strrpos($default, "'");
                 $end = strlen($default) - $pos;


### PR DESCRIPTION
Command atlas-skeleton.php would not work for pgsql without this fix because of the database sequences discovery method.

(with my correct commit author info this time)