### PR TITLE
Issue with views and system tables

### DIFF
--- a/src/Info.php
+++ b/src/Info.php
@@ -40,10 +40,11 @@ abstract class Info
             SELECT table_name
             FROM information_schema.tables
             WHERE table_schema = :schema
+            AND table_type = :type
             ORDER BY table_name
         ';
 
-        return $this->connection->fetchColumn($stm, ['schema' => $schema]);
+        return $this->connection->fetchColumn($stm, ['schema' => $schema, 'type' => 'base table']);
     }
 
     public function fetchColumns(string $table) : array


### PR DESCRIPTION
The [current query](https://github.com/atlasphp/Atlas.Info/blob/1.x/src/Info.php#L39) to retrieve table names from the database ignores the fact that `information_schema.tables` also contains information for views and system tables, which Atlas.Orm doesn't understand.  This pull request adds a where clause to the query to ensure that only the names of user-defined tables are retrieved.

See information about TABLE_TYPE column in e.g. the [MySQL docs](https://dev.mysql.com/doc/refman/5.7/en/tables-table.html), for example.