### PR TITLE
Cast int and float default values to their respective types

### DIFF
--- a/src/Info.php
+++ b/src/Info.php
@@ -40,7 +40,7 @@ abstract class Info
             SELECT table_name
             FROM information_schema.tables
             WHERE table_schema = :schema
-            AND table_type = :type
+            AND lower(table_type) = :type
             ORDER BY table_name
         ';
 
@@ -118,11 +118,31 @@ abstract class Info
             'size' => isset($def['_size']) ? (int) $def['_size'] : null,
             'scale' => isset($def['_scale']) ? (int) $def['_scale'] : null,
             'notnull' => (bool) $def['_notnull'],
-            'default' => $this->getDefault($def['_default']),
+            'default' => $this->extractDefault($def['_default'], $def['_type']),
             'autoinc' => (bool) $def['_autoinc'],
             'primary' => (bool) $def['_primary'],
             'options' => null,
         ];
+    }
+
+    protected function extractDefault($default, string $type)
+    {
+        $type = strtolower($type);
+        $default = $this->getDefault($default);
+
+        if (!isset($default)) {
+            return $default;
+        }
+
+        if (strpos($type, 'int') !== false) {
+            return (int) $default;
+        }
+
+        if ($type == 'float' || $type == 'double') {
+            return (float) $default;
+        }
+
+        return $default;
     }
 
     public function fetchAutoincSequence(string $table) : ?string

--- a/src/SqliteInfo.php
+++ b/src/SqliteInfo.php
@@ -82,7 +82,7 @@ class SqliteInfo extends Info
             'size' => $size,
             'scale' => $scale,
             'notnull' => (bool) ($row['notnull']),
-            'default' => $row['dflt_value'],
+            'default' => $this->extractDefault($row['dflt_value'], $type),
             'autoinc' => null,
             'primary' => (bool) ($row['pk']),
             'options' => null,
@@ -123,7 +123,7 @@ class SqliteInfo extends Info
         // Check the table-creation SQL for the default value to see if it's
         // a keyword and report 'null' in those cases.
 
-        if ($curr['default'] === null) {
+        if (is_string($curr['default']) === false) {
             return null;
         }
 

--- a/tests/MysqlInfoTest.php
+++ b/tests/MysqlInfoTest.php
@@ -24,6 +24,7 @@ class MysqlInfoTest extends InfoTest
                 test_default_null      CHAR(3) DEFAULT NULL,
                 test_default_string    VARCHAR(7) DEFAULT 'string',
                 test_default_number    NUMERIC(5) DEFAULT 12345,
+                test_default_integer   INT DEFAULT 233,
                 test_default_ignore    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 test_enum              ENUM('foo', 'bar', 'baz')
             ) ENGINE=InnoDB
@@ -37,6 +38,7 @@ class MysqlInfoTest extends InfoTest
                 test_default_null      CHAR(3) DEFAULT NULL,
                 test_default_string    VARCHAR(7) DEFAULT 'string',
                 test_default_number    NUMERIC(5) DEFAULT 12345,
+                test_default_integer   INT DEFAULT 233,
                 test_default_ignore    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 test_enum              ENUM('foo', 'bar', 'baz')
             ) ENGINE=InnoDB
@@ -129,6 +131,17 @@ class MysqlInfoTest extends InfoTest
                 'scale' => 0,
                 'notnull' => false,
                 'default' => '12345',
+                'autoinc' => false,
+                'primary' => false,
+                'options' => null,
+            ],
+            'test_default_integer' => [
+                'name' => 'test_default_integer',
+                'type' => 'int',
+                'size' => 10,
+                'scale' => 0,
+                'notnull' => false,
+                'default' => 233,
                 'autoinc' => false,
                 'primary' => false,
                 'options' => null,

--- a/tests/PgsqlInfoTest.php
+++ b/tests/PgsqlInfoTest.php
@@ -19,6 +19,7 @@ class PgsqlInfoTest extends InfoTest
                 test_default_null      CHAR(3) DEFAULT NULL,
                 test_default_string    VARCHAR(7) DEFAULT 'string',
                 test_default_number    NUMERIC(5) DEFAULT 12345,
+                test_default_integer   INT DEFAULT 233,
                 test_default_ignore    TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         ");
@@ -31,6 +32,7 @@ class PgsqlInfoTest extends InfoTest
                 test_default_null      CHAR(3) DEFAULT NULL,
                 test_default_string    VARCHAR(7) DEFAULT 'string',
                 test_default_number    NUMERIC(5) DEFAULT 12345,
+                test_default_integer   INT DEFAULT 233,
                 test_default_ignore    TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         ");
@@ -107,6 +109,17 @@ class PgsqlInfoTest extends InfoTest
                 'scale' => 0,
                 'notnull' => false,
                 'default' => '12345',
+                'autoinc' => false,
+                'primary' => false,
+                'options' => null,
+            ],
+            'test_default_integer' => [
+                'name' => 'test_default_integer',
+                'type' => 'integer',
+                'size' => 32,
+                'scale' => 0,
+                'notnull' => false,
+                'default' => 233,
                 'autoinc' => false,
                 'primary' => false,
                 'options' => null,

--- a/tests/SqliteInfoTest.php
+++ b/tests/SqliteInfoTest.php
@@ -22,6 +22,7 @@ class SqliteInfoTest extends InfoTest
                 test_default_null      CHAR(3) DEFAULT NULL,
                 test_default_string    VARCHAR(7) DEFAULT 'string',
                 test_default_number    NUMERIC(5) DEFAULT 12345,
+                test_default_integer   INT DEFAULT 233,
                 test_default_ignore    TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         ");
@@ -34,6 +35,7 @@ class SqliteInfoTest extends InfoTest
                 test_default_null      CHAR(3) DEFAULT NULL,
                 test_default_string    VARCHAR(7) DEFAULT 'string',
                 test_default_number    NUMERIC(5) DEFAULT 12345,
+                test_default_integer   INT DEFAULT 233,
                 test_default_ignore    TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         ");
@@ -137,6 +139,17 @@ class SqliteInfoTest extends InfoTest
                 'scale' => null,
                 'notnull' => false,
                 'default' => '12345',
+                'autoinc' => false,
+                'primary' => false,
+                'options' => null,
+            ],
+            'test_default_integer' => [
+                'name' => 'test_default_integer',
+                'type' => 'INT',
+                'size' => null,
+                'scale' => null,
+                'notnull' => false,
+                'default' => 233,
                 'autoinc' => false,
                 'primary' => false,
                 'options' => null,

--- a/tests/SqlsrvInfoTest.php
+++ b/tests/SqlsrvInfoTest.php
@@ -7,10 +7,10 @@ class SqlsrvInfoTest extends InfoTest
 {
     protected function create()
     {
-        $this->pdo->query("CREATE SCHEMA {$this->schemaName1}");
-        $this->pdo->query("CREATE SCHEMA {$this->schemaName2}");
+        $this->connection->query("CREATE SCHEMA {$this->schemaName1}");
+        $this->connection->query("CREATE SCHEMA {$this->schemaName2}");
 
-        $this->pdo->query("
+        $this->connection->query("
             CREATE TABLE {$this->schemaName1}.{$this->tableName} (
                 id                     INT IDENTITY PRIMARY KEY,
                 name                   VARCHAR(50) NOT NULL,
@@ -18,11 +18,12 @@ class SqlsrvInfoTest extends InfoTest
                 test_default_null      CHAR(3) DEFAULT NULL,
                 test_default_string    VARCHAR(7) DEFAULT 'string',
                 test_default_number    NUMERIC(5) DEFAULT 12345,
+                test_default_integer   INT DEFAULT 233,
                 test_default_ignore    DATETIME DEFAULT CURRENT_TIMESTAMP
             )
         ");
 
-        $this->pdo->query("
+        $this->connection->query("
             CREATE TABLE {$this->schemaName2}.{$this->tableName} (
                 id                     INT IDENTITY PRIMARY KEY,
                 name                   VARCHAR(50) NOT NULL,
@@ -30,6 +31,7 @@ class SqlsrvInfoTest extends InfoTest
                 test_default_null      CHAR(3) DEFAULT NULL,
                 test_default_string    VARCHAR(7) DEFAULT 'string',
                 test_default_number    NUMERIC(5) DEFAULT 12345,
+                test_default_integer   INT DEFAULT 233,
                 test_default_ignore    DATETIME DEFAULT CURRENT_TIMESTAMP
             )
         ");
@@ -44,18 +46,18 @@ class SqlsrvInfoTest extends InfoTest
 
         $stm = "INSERT INTO {$this->schemaName1}.{$this->tableName} (name) VALUES (:name)";
         foreach ($names as $name) {
-            $sth = $this->pdo->prepare($stm);
+            $sth = $this->connection->prepare($stm);
             $sth->execute(['name' => $name]);
         }
     }
 
     protected function drop()
     {
-        $this->pdo->query("DROP TABLE IF EXISTS {$this->schemaName1}.{$this->tableName}");
-        $this->pdo->query("DROP SCHEMA IF EXISTS {$this->schemaName1}");
+        $this->connection->query("DROP TABLE IF EXISTS {$this->schemaName1}.{$this->tableName}");
+        $this->connection->query("DROP SCHEMA IF EXISTS {$this->schemaName1}");
 
-        $this->pdo->query("DROP TABLE IF EXISTS {$this->schemaName2}.{$this->tableName}");
-        $this->pdo->query("DROP SCHEMA IF EXISTS {$this->schemaName2}");
+        $this->connection->query("DROP TABLE IF EXISTS {$this->schemaName2}.{$this->tableName}");
+        $this->connection->query("DROP SCHEMA IF EXISTS {$this->schemaName2}");
     }
 
     public function provideFetchTableNames()
@@ -68,8 +70,7 @@ class SqlsrvInfoTest extends InfoTest
                     'spt_fallback_db',
                     'spt_fallback_dev',
                     'spt_fallback_usg',
-                    'spt_monitor',
-                    'spt_values',
+                    'spt_monitor'
                 ],
             ],
             [
@@ -152,6 +153,17 @@ class SqlsrvInfoTest extends InfoTest
                 'scale' => 0,
                 'notnull' => false,
                 'default' => '12345',
+                'autoinc' => false,
+                'primary' => false,
+                'options' => null,
+            ],
+            'test_default_integer' => [
+                'name' => 'test_default_integer',
+                'type' => 'int',
+                'size' => 10,
+                'scale' => 0,
+                'notnull' => false,
+                'default' => 233,
                 'autoinc' => false,
                 'primary' => false,
                 'options' => null,


### PR DESCRIPTION
Noticed during skeleton generation that default row values were always strings, even when the column type was 'int' or 'float'. Normally when fetching data from the db, these values are represented by strings coming out of the pdo driver, however when you have a pdo connection that disables stringifying fetches, you can get ints and floats out of a query. The problem here is that this rule doesn't apply to the default_value column.

The absolutely correct way to do this would be to attempt to emulate the PDO option 'ATTR_STRINGIFY_FETCHES' only when it's enabled, but I noticed that a lot of the drivers don't actually support _reading_ those options (they throw when you attempt to call $pdo->getAttribute). I'm not sure I know a good way to get around this.

Had to do several additional things to get the test suite to run.. Tried to make all of my moves in a non BC breaking way, please poke holes in this. I will inline comments to explain them.