### PR TITLE
Fix empty string defaults for MariaDB

### DIFF
--- a/src/MysqlInfo.php
+++ b/src/MysqlInfo.php
@@ -57,6 +57,14 @@ class MysqlInfo extends Info
             $column['default'] = null;
         }
 
+        if (
+            $this->maria
+            && (in_array($column['type'], ['char', 'varchar', 'text']))
+            && $column['default'] === '\'\''
+        ) {
+            $column['default'] = '';
+        }
+
         $extended = trim($def['_extended']);
 
         $pos = stripos($extended, 'unsigned');


### PR DESCRIPTION
If the db is MariaDB and the field type is text, char or varchar and the default is `''` then set it to empty string rather than the reported string `"''"`