### PR TITLE
Fix nullable number types with a null default for mariaDb

### DIFF
--- a/src/Info.php
+++ b/src/Info.php
@@ -121,17 +121,17 @@ abstract class Info
             'size' => isset($def['_size']) ? (int) $def['_size'] : null,
             'scale' => isset($def['_scale']) ? (int) $def['_scale'] : null,
             'notnull' => (bool) $def['_notnull'],
-            'default' => $this->extractDefault($def['_default'], $def['_type']),
+            'default' => $this->extractDefault($def['_default'], $def['_type'], !$def['_notnull']),
             'autoinc' => (bool) $def['_autoinc'],
             'primary' => (bool) $def['_primary'],
             'options' => null,
         ];
     }
 
-    protected function extractDefault($default, string $type)
+    protected function extractDefault($default, string $type, bool $canBeNull)
     {
         $type = strtolower($type);
-        $default = $this->getDefault($default);
+        $default = $this->getDefault($default, $type, $canBeNull);
 
         if ($default === null) {
             return $default;
@@ -160,5 +160,5 @@ abstract class Info
 
     abstract protected function getAutoincSql() : string;
 
-    abstract protected function getDefault($default);
+    abstract protected function getDefault($default, $type, $canBeNull);
 }

--- a/src/MysqlInfo.php
+++ b/src/MysqlInfo.php
@@ -49,14 +49,6 @@ class MysqlInfo extends Info
     {
         $column = parent::extractColumn($schema, $table, $def);
 
-        if (
-            $this->maria
-            && $column['notnull'] == 0
-            && $column['default'] === 'NULL'
-        ) {
-            $column['default'] = null;
-        }
-
         $extended = trim($def['_extended']);
 
         $pos = stripos($extended, 'unsigned');
@@ -75,9 +67,13 @@ class MysqlInfo extends Info
         return $column;
     }
 
-    protected function getDefault($default)
+    protected function getDefault($default, $type, $canBeNull)
     {
         if ($default === null) {
+            return null;
+        }
+
+        if ($this->maria && $canBeNull && $default === 'NULL') {
             return null;
         }
 

--- a/src/PgsqlInfo.php
+++ b/src/PgsqlInfo.php
@@ -72,7 +72,7 @@ class PgsqlInfo extends Info
                 END";
     }
 
-    protected function getDefault($default)
+    protected function getDefault($default, $type, $canBeNull)
     {
         // null?
         if ($default === null || strtoupper($default) === 'NULL') {

--- a/src/SqliteInfo.php
+++ b/src/SqliteInfo.php
@@ -82,7 +82,7 @@ class SqliteInfo extends Info
             'size' => $size,
             'scale' => $scale,
             'notnull' => (bool) ($row['notnull']),
-            'default' => $this->extractDefault($row['dflt_value'], $type),
+            'default' => $this->extractDefault($row['dflt_value'], $type, !$def['notnull']),
             'autoinc' => null,
             'primary' => (bool) ($row['pk']),
             'options' => null,
@@ -104,7 +104,7 @@ class SqliteInfo extends Info
         return $this->connection->fetchValue($cmd, ['table' => $table]);
     }
 
-    protected function getDefault($default)
+    protected function getDefault($default, $type, $canBeNull)
     {
         return $default;
     }

--- a/src/SqliteInfo.php
+++ b/src/SqliteInfo.php
@@ -82,7 +82,7 @@ class SqliteInfo extends Info
             'size' => $size,
             'scale' => $scale,
             'notnull' => (bool) ($row['notnull']),
-            'default' => $this->extractDefault($row['dflt_value'], $type, !$def['notnull']),
+            'default' => $this->extractDefault($row['dflt_value'], $type, !$row['notnull']),
             'autoinc' => null,
             'primary' => (bool) ($row['pk']),
             'options' => null,

--- a/src/SqlsrvInfo.php
+++ b/src/SqlsrvInfo.php
@@ -26,7 +26,7 @@ class SqlsrvInfo extends Info
                 )";
     }
 
-    protected function getDefault($default)
+    protected function getDefault($default, $type, $canBeNull)
     {
         // no default
         if ($default === null) {


### PR DESCRIPTION
Nullable numeric field types are being incorrectly set to 0 or 0.0 because the recent patch for mariadb's behaviour of using 'NULL' for a null default comes too late in the processing of defaults. By the time the patch in the Mysql info subclass's extractColumn method is run the parent Info class's extractDefault() method has already replaced the 'NULL' string default for float, real, double and int types with 0 or 0.0.

This PR extends the getDefault() by providing a `type` parameter and a `canBeNull` parameter so each Info subclass can make better decisions on handling defaults. The PR also moves the mysql Info subclass's patch for handling `'NULL'` string into the mysql Info subclass's getDefault() method so the conversion from `'NULL'` to `null` happens early enough to avoid the issues with int, float, real and double.

A brief glance at the other sublclasses suggests further refactoring using the new `type` and `canBeNull` parameters to `getDefault()` would be possible and tidy up some 'hacky' assumptions. It would also be possible to move the patch in PR #8 into the mysql `getDefault()` method for neatness.