### PR TITLE
Extract comments from columns

### DIFF
--- a/src/Info.php
+++ b/src/Info.php
@@ -62,6 +62,8 @@ abstract class Info
 
         $autoinc = $this->getAutoincSql();
         $extended = $this->getExtendedSql();
+        $commentField = $this->getCommentFieldSql();
+        $commentJoin = $this->getCommentJoinSql();
 
         $stm = "
             SELECT
@@ -81,7 +83,7 @@ abstract class Info
                 CASE
                     WHEN table_constraints.constraint_type = 'PRIMARY KEY' THEN 1
                     ELSE 0
-                END AS _primary{$extended}
+                END AS _primary{$extended}{$commentField}
             FROM information_schema.columns
                 LEFT JOIN information_schema.key_column_usage
                     ON columns.table_schema = key_column_usage.table_schema
@@ -90,7 +92,7 @@ abstract class Info
                 LEFT JOIN information_schema.table_constraints
                     ON key_column_usage.table_schema = table_constraints.table_schema
                     AND key_column_usage.table_name = table_constraints.table_name
-                    AND key_column_usage.constraint_name = table_constraints.constraint_name
+                    AND key_column_usage.constraint_name = table_constraints.constraint_name{$commentJoin}
             WHERE columns.table_schema = :schema
             AND columns.table_name = :table
             ORDER BY columns.ordinal_position
@@ -124,6 +126,7 @@ abstract class Info
             'default' => $this->extractDefault($def['_default'], $def['_type'], !$def['_notnull']),
             'autoinc' => (bool) $def['_autoinc'],
             'primary' => (bool) $def['_primary'],
+            'comment' => isset($def['_comment']) && trim($def['_comment']) !== '' ? $def['_comment'] : null,
             'options' => null,
         ];
     }
@@ -154,6 +157,16 @@ abstract class Info
     }
 
     protected function getExtendedSql() : string
+    {
+        return '';
+    }
+
+    protected function getCommentFieldSql() : string
+    {
+        return '';
+    }
+
+    protected function getCommentJoinSql() : string
     {
         return '';
     }

--- a/src/MysqlInfo.php
+++ b/src/MysqlInfo.php
@@ -45,6 +45,12 @@ class MysqlInfo extends Info
                 columns.column_type as _extended';
     }
 
+    protected function getCommentFieldSql(): string
+    {
+        return ',
+                columns.column_comment as _comment';
+    }
+
     protected function extractColumn(string $schema, string $table, array $def) : array
     {
         $column = parent::extractColumn($schema, $table, $def);

--- a/src/PgsqlInfo.php
+++ b/src/PgsqlInfo.php
@@ -72,6 +72,20 @@ class PgsqlInfo extends Info
                 END";
     }
 
+    protected function getCommentFieldSql() : string
+    {
+        return ',
+                pg_catalog.col_description(pg_catalog.pg_statio_all_tables.relid, columns.ordinal_position::int) AS _comment';
+    }
+
+    protected function getCommentJoinSql() : string
+    {
+        return '
+            LEFT JOIN pg_catalog.pg_statio_all_tables ON pg_catalog.pg_statio_all_tables.relid = columns.table_name::regclass
+                LEFT JOIN pg_catalog.pg_description ON pg_catalog.pg_description.objoid = pg_catalog.pg_statio_all_tables.relid
+                AND pg_catalog.pg_description.objsubid = columns.ordinal_position';
+    }
+
     protected function getDefault($default, $type, $nullable)
     {
         // null?

--- a/src/SqliteInfo.php
+++ b/src/SqliteInfo.php
@@ -85,6 +85,7 @@ class SqliteInfo extends Info
             'default' => $this->extractDefault($row['dflt_value'], $type, ! $row['notnull']),
             'autoinc' => null,
             'primary' => (bool) ($row['pk']),
+            'comment' => null,
             'options' => null,
         ];
     }

--- a/tests/InfoTest.php
+++ b/tests/InfoTest.php
@@ -88,6 +88,7 @@ abstract class InfoTest extends \PHPUnit\Framework\TestCase
             'default',
             'autoinc',
             'primary',
+            'comment',
         ];
         foreach ($actualCols as $colName => $actualCol) {
             $expectCol = $expectCols[$colName];

--- a/tests/MysqlInfoTest.php
+++ b/tests/MysqlInfoTest.php
@@ -26,7 +26,8 @@ class MysqlInfoTest extends InfoTest
                 test_default_number    NUMERIC(5) DEFAULT 12345,
                 test_default_integer   INT DEFAULT 233,
                 test_default_ignore    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                test_enum              ENUM('foo', 'bar', 'baz')
+                test_enum              ENUM('foo', 'bar', 'baz'),
+                test_comment           VARCHAR(50) DEFAULT NULL COMMENT 'Example'
             ) ENGINE=InnoDB
         ");
 
@@ -40,7 +41,8 @@ class MysqlInfoTest extends InfoTest
                 test_default_number    NUMERIC(5) DEFAULT 12345,
                 test_default_integer   INT DEFAULT 233,
                 test_default_ignore    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                test_enum              ENUM('foo', 'bar', 'baz')
+                test_enum              ENUM('foo', 'bar', 'baz'),
+                test_comment           VARCHAR(50) DEFAULT NULL COMMENT 'Example'
             ) ENGINE=InnoDB
         ");
 
@@ -78,6 +80,7 @@ class MysqlInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => true,
                 'primary' => true,
+                'comment' => null,
                 'options' => null,
             ],
             'name' => [
@@ -89,6 +92,7 @@ class MysqlInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_size_scale' => [
@@ -100,6 +104,7 @@ class MysqlInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_null' => [
@@ -111,6 +116,7 @@ class MysqlInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_string' => [
@@ -122,6 +128,7 @@ class MysqlInfoTest extends InfoTest
                 'default' => 'string',
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_number' => [
@@ -133,6 +140,7 @@ class MysqlInfoTest extends InfoTest
                 'default' => '12345',
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_integer' => [
@@ -144,6 +152,7 @@ class MysqlInfoTest extends InfoTest
                 'default' => 233,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_ignore' => [
@@ -155,6 +164,7 @@ class MysqlInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_enum' => [
@@ -166,7 +176,20 @@ class MysqlInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => ['foo', 'bar', 'baz'],
+            ],
+            'test_comment' => [
+                'name' => 'test_comment',
+                'type' => 'varchar',
+                'size' => 50,
+                'scale' => null,
+                'notnull' => false,
+                'default' => null,
+                'autoinc' => false,
+                'primary' => false,
+                'comment' => 'Example',
+                'options' => null,
             ],
         ];
         $issue3Columns = [
@@ -179,6 +202,7 @@ class MysqlInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => true,
+                'comment' => null,
                 'options' => null,
             ],
         ];

--- a/tests/PgsqlInfoTest.php
+++ b/tests/PgsqlInfoTest.php
@@ -20,9 +20,11 @@ class PgsqlInfoTest extends InfoTest
                 test_default_string    VARCHAR(7) DEFAULT 'string',
                 test_default_number    NUMERIC(5) DEFAULT 12345,
                 test_default_integer   INT DEFAULT 233,
-                test_default_ignore    TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                test_default_ignore    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                test_comment           VARCHAR(50) DEFAULT NULL
             )
         ");
+        $this->connection->query("COMMENT ON COLUMN {$this->tableName}.test_comment IS 'Example'");
 
         $this->connection->query("
             CREATE TABLE {$this->schemaName2}.{$this->tableName} (
@@ -33,9 +35,11 @@ class PgsqlInfoTest extends InfoTest
                 test_default_string    VARCHAR(7) DEFAULT 'string',
                 test_default_number    NUMERIC(5) DEFAULT 12345,
                 test_default_integer   INT DEFAULT 233,
-                test_default_ignore    TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                test_default_ignore    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                test_comment           VARCHAR(50) DEFAULT NULL
             )
         ");
+        $this->connection->query("COMMENT ON COLUMN {$this->schemaName2}.{$this->tableName}.test_comment IS 'Example'");
     }
 
     protected function drop()
@@ -56,6 +60,7 @@ class PgsqlInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => true,
                 'primary' => true,
+                'comment' => null,
                 'options' => null,
             ],
             'name' => [
@@ -67,6 +72,7 @@ class PgsqlInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_size_scale' => [
@@ -78,6 +84,7 @@ class PgsqlInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_null' => [
@@ -89,6 +96,7 @@ class PgsqlInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_string' => [
@@ -100,6 +108,7 @@ class PgsqlInfoTest extends InfoTest
                 'default' => 'string',
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_number' => [
@@ -111,6 +120,7 @@ class PgsqlInfoTest extends InfoTest
                 'default' => '12345',
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_integer' => [
@@ -122,6 +132,7 @@ class PgsqlInfoTest extends InfoTest
                 'default' => 233,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_ignore' => [
@@ -133,6 +144,19 @@ class PgsqlInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
+                'options' => null,
+            ],
+            'test_comment' => [
+                'name' => 'test_comment',
+                'type' => 'character varying',
+                'size' => 50,
+                'scale' => null,
+                'notnull' => false,
+                'default' => null,
+                'autoinc' => false,
+                'primary' => false,
+                'comment' => 'Example',
                 'options' => null,
             ],
         ];

--- a/tests/SqliteInfoTest.php
+++ b/tests/SqliteInfoTest.php
@@ -86,6 +86,7 @@ class SqliteInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => true,
                 'primary' => true,
+                'comment' => null,
                 'options' => null,
             ],
             'name' => [
@@ -97,6 +98,7 @@ class SqliteInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_size_scale' => [
@@ -108,6 +110,7 @@ class SqliteInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_null' => [
@@ -119,6 +122,7 @@ class SqliteInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_string' => [
@@ -130,6 +134,7 @@ class SqliteInfoTest extends InfoTest
                 'default' => 'string',
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_number' => [
@@ -141,6 +146,7 @@ class SqliteInfoTest extends InfoTest
                 'default' => '12345',
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_integer' => [
@@ -152,6 +158,7 @@ class SqliteInfoTest extends InfoTest
                 'default' => 233,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_ignore' => [
@@ -163,6 +170,7 @@ class SqliteInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
         ];
@@ -177,6 +185,7 @@ class SqliteInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => true,
+                'comment' => null,
                 'options' => null,
             ],
         ];

--- a/tests/SqlsrvInfoTest.php
+++ b/tests/SqlsrvInfoTest.php
@@ -100,6 +100,7 @@ class SqlsrvInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => true,
                 'primary' => true,
+                'comment' => null,
                 'options' => null,
             ],
             'name' => [
@@ -111,6 +112,7 @@ class SqlsrvInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_size_scale' => [
@@ -122,6 +124,7 @@ class SqlsrvInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_null' => [
@@ -133,6 +136,7 @@ class SqlsrvInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_string' => [
@@ -144,6 +148,7 @@ class SqlsrvInfoTest extends InfoTest
                 'default' => 'string',
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_number' => [
@@ -155,6 +160,7 @@ class SqlsrvInfoTest extends InfoTest
                 'default' => '12345',
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_integer' => [
@@ -166,6 +172,7 @@ class SqlsrvInfoTest extends InfoTest
                 'default' => 233,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
             'test_default_ignore' => [
@@ -177,6 +184,7 @@ class SqlsrvInfoTest extends InfoTest
                 'default' => null,
                 'autoinc' => false,
                 'primary' => false,
+                'comment' => null,
                 'options' => null,
             ],
         ];


### PR DESCRIPTION
This is a suggestion to extract comments of columns for MySQL and PostgreSQL.
Unfortunately, SQLite does not support the comments and at the moment I have no Microsoft SQL Server instance.

Related to #13 